### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,16 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+
+target_include_directories(cpackexamplelib
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/cpackexamplelib
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
 
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
@@ -26,3 +36,18 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+# Create install targets
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+  )
+  
+# Adding other cmake modules (standard like this)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# Include our packaging module (standard like this)
+include(CPackConfig)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,20 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE sumanth0703 cpack project"
+  CACHE STRING "Extended summary.")
+
+set(CPACK_PACKAGE_VENDOR "Sai Sumanth Moturu")
+set(CPACK_PACKAGE_CONTACT "sumanthmoturu0703@gmail.com")
+set(CPACK_PACKAGE_MAINTAINERS "Sai Sumanth Moturu ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/sumanth0703/cpack-exercise-wt2223.git")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+# Debian packaging section
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+# strip really all Debug symbols
+set(CPACK_STRIP_FILES TRUE)
+
+include(CPack)


### PR DESCRIPTION
Step 1 : Clone the repository
```git clone git@github.com:sumanth0703/cpack-exercise-wt2223.git```

Step 2 : Build the container with the command
```docker build -t sumanth0703_finallywonthefight .```

Step 3: Run the container
```docker run --rm -it --mount type=bind, source="$(pwd)",target=/mnt/cpack-exercise sumanth0703_finallywonthefight```

Step 4 : In the container, ``` cd /mnt/cpack-exercise```

Step 5 : Now make the required build directory, ```mkdir build && cd build```

Step 6 : Run the cmake command as mentioned in the lecture,
```cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..```

Step 7 : Make Packages,
``` make package```
Preferably, ```make clean && make package```

Step 8 : Install the package,
```apt install ./cpackexample_0.1.0_amd64.deb```
If not in a container, then
```sudo apt install ./cpackexample_0.1.0_amd64.deb```