### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ DEAL_II_SETUP_TARGET(cpackexamplelib)
 
 target_include_directories(cpackexamplelib
         PRIVATE
-        # where the library itself will look for its internal headers
         ${CMAKE_CURRENT_SOURCE_DIR}/fem
         ${CMAKE_CURRENT_SOURCE_DIR}/filesystem
         ${CMAKE_CURRENT_SOURCE_DIR}/flatset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER
+        "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
 
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
@@ -26,3 +28,22 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+target_include_directories(cpackexamplelib
+        PRIVATE
+        # where the library itself will look for its internal headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/fem
+        ${CMAKE_CURRENT_SOURCE_DIR}/filesystem
+        ${CMAKE_CURRENT_SOURCE_DIR}/flatset
+        ${CMAKE_CURRENT_SOURCE_DIR}/yamlParser)
+
+include(GNUInstallDirs)
+install(TARGETS cpackexamplelib "${PROJECT_NAME}"
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+        INCLUDES DESTINATION  ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(CPackConfig)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,18 +1,18 @@
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "CPack Exercise Winter Semester 2022-2023"
-        CACHE STRING "Winter's summary.")
+        CACHE STRING "CPack Exercise to package code into TGZ and DEB files. Winter Semester 2022-2023")
 
-set(CPACK_PACKAGE_VENDOR "Mustafa")
+set(CPACK_PACKAGE_VENDOR "Mustafa Cevik")
 set(CPACK_PACKAGE_CONTACT "mustafacevik963@gmail.com")
 set(CPACK_PACKAGE_MAINTAINERS "SSE lectured student ${CPACK_PACKAGE_CONTACT}")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/musteng")
-set(CPACK_GENERATOR "TGZ;DEB")
-
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/musteng/cpack-exercise-wt2223.git")
+set(CPACK_GENERATOR "TGZ;DEB") # Packages to be generated
 
 # Debian packaging section
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
 set(CPACK_STRIP_FILES TRUE)
+# Debian packaging section end
 
 include(CPack)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,18 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "CPack Exercise Winter Semester 2022-2023"
+        CACHE STRING "Winter's summary.")
+
+set(CPACK_PACKAGE_VENDOR "Mustafa")
+set(CPACK_PACKAGE_CONTACT "mustafacevik963@gmail.com")
+set(CPACK_PACKAGE_MAINTAINERS "SSE lectured student ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/musteng")
+set(CPACK_GENERATOR "TGZ;DEB")
+
+
+# Debian packaging section
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_STRIP_FILES TRUE)
+
+include(CPack)


### PR DESCRIPTION
To be able to correctly operate the code, make sure `Docker` is running and follow the below steps :

1. Clone the repository via `git clone https://github.com/musteng/cpack-exercise-wt2223.git`
3. Enter the source code folder `cpack-exercise-wt2223`
4. To create a docker image, run the command `docker build -t <imagename>:<tag> .`
5. After image creation is finished, run a container by using the created image via `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise <imagename>:<tag>`
6. Now you are inside the container, change the directory `cd /mnt/cpack-exercise`
7. Run commands to create TGZ and DEB packages `mkdir build`, `cd build`, `cmake ..`, `make` and `make package`
8. TGZ and DEB packages is created at current folder, to inspect DEB package, run the command` lintian ./cpackexample_0.1.0_arm64.deb`
9. See the results in below picture.

<img width="958" alt="Screen Shot 2022-12-03 at 23 54 35" src="https://user-images.githubusercontent.com/84103874/205465792-a2ff73f5-9078-46ec-b70b-f7384c5826c3.png">
