### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,27 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "fem/fem.hpp;filesystem/filesystem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib
+    PRIVATE
+        # where the library itself will look for its internal headers
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+        # where top-level project will look for the library's public headers
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        # where external projects will look for the library's public headers
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+
+include(GNUInstallDirs)
+install(TARGETS cpackexamplelib ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  )
+
+include(cmake/CPackConfig.cmake)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,13 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "mananijh - cpack exercise solution - sse")
+set(CPACK_PACKAGE_VENDOR "mananijh CPack Solution")
+set(CPACK_PACKAGE_MAINTAINERS "Jayesh Manani")
+set(CPACK_PACKAGE_CONTACT "jsmanani@gmail.com")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/jayeshmanani/cpack-exercise-wt2223")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_STRIP_FILES TRUE) # for stripping the files set it TRUE, otherwise just comment the line
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+include(CPack)


### PR DESCRIPTION
Step to Setup

- Clone the repository (cpack-exercise-wt2223)

- cd into cpack-exercise-wt2223 directory

- Build a docker container image
    `docker build -t IMAGENAME .`

- Run the docker container and mount the current working directory
    `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME` 

- After container starts, runt the following commands to accomplish the task to create the package
`cd /mnt/cpack-exercise` (to cd into the shared directory)
`mkdir build` (create the build directory)
`cd build` (go into the build directory)

- to create the package file 
`cmake ..`
`make`
`make package`

- to install and check the package
`apt install ./cpackexample_0.1.0_amd64.deb`
`cpackexample`
`which cpackexample` (to check the location where it is stored)

- Inspect the Debian package with lintian
`lintian ./cpackexample_0.1.0_amd64.deb`

The output of lintian look like

![lintian debian package checking](https://user-images.githubusercontent.com/30725294/205790252-0d75394a-02d3-44ce-8d8f-1055a4a08a56.png)

The size check with `du - h FILENAME`

Generated with Stripped File (use of `set(CPACK_STRIP_FILES "TRUE")` in cPackConfig.cmake)
![stripped files](https://user-images.githubusercontent.com/30725294/205790358-9bdabb90-7ef0-4a4d-bd54-72b2fb967686.png)

Generated with Unstripped File (no use of `set(CPACK_STRIP_FILES "TRUE")` in cPackConfig.cmake)
![unstripped files](https://user-images.githubusercontent.com/30725294/205790364-4fa5f0df-1dcd-4a23-b1be-588327be1bd1.png)


