### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,33 @@ find_package(yaml-cpp
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "flatset/flatset.hpp;filesystem/filesystem.hpp;fem/fem.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib 
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/cpackexamplelib
+	PUBLIC 
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>	
+)
+
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+install(TARGETS cpackexample cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/cpackexamplelib
+)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(CPackConfig)
+

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,18 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE cpack exercise")
+set(CPACK_PACKAGE_DESCRIPTON "SSE cpack exercise long description")
+
+set(CPACK_PACKAGE_VENDOR "Moritz Strack")
+set(CPACK_PACKAGE_CONTACT "st166660@stud.uni-stuttgart.de")
+set(CPACK_PACKAGE_MAINTAINERS "SEE lecturers and attendends ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Straggio/cpack-exercise-wt2223")
+
+set(CPACK_STRIP_FILES TRUE)
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+include(CPack)


### PR DESCRIPTION
To run example:
- Build docker image:
` docker build -t IMAGENAME . `
- Run docker container:
` docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME `
- Go to working directory and create build folder:
` cd mnt/cpack-exercise/ && mkdir build && cd build/ `
- Run cmake command:
` cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .. `
- Make packages:
` make package `
- Install deb package:
` apt install ./cpackexample_0.1.0_amd64.deb  `
