### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,31 @@ find_package(yaml-cpp
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib
+	PRIVATE
+	    ${CMAKE_CURRENT_SOURCE_DIR}
+	PUBLIC
+	    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexample>
+)
+
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(CPackConfig)
+
+include(GNUInstallDirs)
+install(TARGETS cpackexample cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexample
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexample
+  )

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,17 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_MAINTAINERS "kurtyisn (Sinan Kurtyigit)")
+set(CPACK_PACKAGE_CONTACT "st142476@stud.uni-stuttgart.de")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE cpack example project")
+set(CPACK_PACKAGE_VENDOR "kurtyisn (Sinan Kurtyigit)")
+set(CPACK_PACKAGE_HOMEPAGE "https://github.com/seinan9/cpack-exercise-wt2223")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_DEBIAN_PACKAGE_NAME cpackexample)
+set(CPACK_DEBIAN_PACKAGE_VERSION 1.0)
+set(CPACK_DEBIAN_PACKAGE_RELEASE 1)
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE amd64)
+set(CPACK_STRIP_FILES "/usr/bin/cpackexample")
+include(CPack)

--- a/lintian_output
+++ b/lintian_output
@@ -1,0 +1,5 @@
+E: cpackexample: extended-description-is-empty
+E: cpackexample: no-changelog usr/share/doc/cpackexample/changelog.Debian.gz (non-native package)
+E: cpackexample: no-copyright-file
+E: cpackexample: no-phrase Maintainer st142476@stud.uni-stuttgart.de
+W: cpackexample: no-manual-page usr/bin/cpackexample


### PR DESCRIPTION
## Instructions
> docker build -t IMAGENAME .

> docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME

> cd /mnt/cpack-exercise

> mkdir build && cd build && cmake ..

> make package

> apt install ./cpackexample_1.0-1_amd64.deb

> cpackexample

## Lintian Report
E: cpackexample: extended-description-is-empty
E: cpackexample: no-changelog usr/share/doc/cpackexample/changelog.Debian.gz (non-native package)
E: cpackexample: no-copyright-file
E: cpackexample: no-phrase Maintainer st142476@stud.uni-stuttgart.de
W: cpackexample: no-manual-page usr/bin/cpackexample