### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION "3.12")
 
 FIND_PACKAGE(deal.II 9.1.0 REQUIRED
   HINTS ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
-  )
+)
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
 project("cpackexample" VERSION 0.1.0)
@@ -11,12 +11,12 @@ find_package(Boost
   1.65.1
   REQUIRED
   filesystem
-  )
+)
 
 find_package(yaml-cpp
   0.6.0
   REQUIRED
-  )
+)
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 
@@ -26,3 +26,35 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "fem/fem.hpp;filesystem/filesystem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib
+  PRIVATE
+
+  # where the library itself will look for its internal headers
+  ${CMAKE_CURRENT_SOURCE_DIR}
+
+  PUBLIC
+
+  # where top-level project will look for the library's public headers
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+
+  # where external projects will look for the library's public headers
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+)
+
+# Adding other cmake modules (standard like this)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Include our packaging module (standard like this)
+include(CPackConfig)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,26 +6,27 @@ COPY inittimezone /usr/local/bin/inittimezone
 RUN apt-get -qq update && \
     inittimezone && \
     apt-get -qq -y install \
-        build-essential \
-        cmake \
-        g++ \
-        git \
-        libboost-all-dev \
-        wget \
-        libdeal.ii-dev \
-        vim \
-        tree \
-        lintian
-        
+    build-essential \
+    cmake \
+    g++ \
+    git \
+    libboost-all-dev \
+    wget \
+    libdeal.ii-dev \
+    vim \
+    tree \
+    lintian \
+    libyaml-cpp-dev
+
 # Get, unpack, build, and install yaml-cpp        
 RUN mkdir software && cd software && \
     git clone https://github.com/jbeder/yaml-cpp.git && \
     cd yaml-cpp && mkdir build && cd build && \
     cmake -DYAML_BUILD_SHARED_LIBS=ON .. && make -j4 && make install
-    
+
 # This is some strange Docker problem. Normally, you don't need to add /usr/local to these
 ENV LIBRARY_PATH $LIBRARY_PATH:/usr/local/lib/
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/lib/
 ENV PATH $PATH:/usr/local/bin/
 
-CMD ["/bin/bash"]
+CMD mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ../mnt/cpack-exercise && make package && cp cpackexample_0.1.0_amd64.deb ../mnt/cpack-exercise && cp cpackexample-0.1.0-Linux.tar.gz ../mnt/cpack-exercise && /bin/bash

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,18 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_MAINTAINERS "lingemkm")
+set(CPACK_PACKAGE_CONTACT "Kim Lingemann <st160814@stud.uni-stuttgart.de>")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE - Exercise 03, CPack"
+    CACHE STRING "Extended summary.")
+set(CPACK_PACKAGE_VENDOR "lingemkm")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/kimsina/cpack-exercise-wt2223")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+# Debian packaging section
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_PACKAGE_DESCRIPTION "This is the third exercise of Simulation Software Engineering. It covers CPack.")
+
+include(CPack)


### PR DESCRIPTION
To test my code, please follow the steps below. Please note that these steps contain the optional bonus task.
1. Clone the repository and navigate to it.
2. Build a Docker image from the Dockerfile. You can do this by running e.g. `docker build -t cpack-ex03 .`.
3. Run a container from the built image using `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise cpack-ex03`. 
This will automatically create the packages and copy them to the host system. You should be able to see them in the folder from which you called the previous commands.
4. After the packages are created, you should be in a folder called `build` within the docker container. From here on, you can install the Debian package using `apt install ./cpackexample_0.1.0_amd64.deb`
5. Check if the installation was successful by calling `cpackexample`
6. Finally, you can inspect the Debian package with `lintian cpackexample_0.1.0_amd64.deb `

I worked on all optional tasks.
- Step 3, optional task: In the `build` folder, call `dpkg --info cpackexample_0.1.0_amd64.deb`. The output now shows `libyaml-cpp0.7 (>= 0.7.0)` as a dependency.
- Step 4, optional task 1:
This screenshot shows the file size of the `.deb` file with unstripped files:
![file_size_unstripped](https://user-images.githubusercontent.com/44905449/206216422-3a582be5-6ecd-4967-9ece-883370512452.png)
This screenshot shows the file size of the `.deb` file with stripped files:
![file_size_stripped](https://user-images.githubusercontent.com/44905449/206216598-57966bea-8005-408f-8538-6cd549a24556.png)
- Step 4, optional task 2:
Lintian output before:
![lintian_output_before_lingemkm](https://user-images.githubusercontent.com/44905449/206216989-bd2cb6be-c180-4809-928d-ab4bf301e20e.png)
Lintian output after:
![lintian_output_after_lingemkm](https://user-images.githubusercontent.com/44905449/206217049-c2cd734d-4c4d-4b0d-b723-234c54fab33e.png)

  - To get rid of the extended-description-is-empty error, I added `set(CPACK_PACKAGE_DESCRIPTION "...")` in `CPackConfig.cmake`.
  - Both unstripped-binary-or-object errors were solved by adding `set(CPACK_STRIP_FILES TRUE)`.
  - The no-phrase error was fixed by adding my name to `set(CPACK_PACKAGE_CONTACT "...") ` and using angle brackets around the mail address.

- Optional Bonus Task:
After step 3 in the guide at the top, you should see the created files on your host system.


