### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,22 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+# Create install targets
+include(GNUInstallDirs)
+install(TARGETS cpackexample cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+)
+
+# strip really all Debug symbols
+set(CPACK_STRIP_FILES TRUE)
+
+# Adding other cmake modules (standard like this)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# Include our packaging module (standard like this)
+include(CPackConfig)
+

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,11 +1,12 @@
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
-
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE cpack example project")
 set(CPACK_PACKAGE_DESCRIPTION "This is an example project to test CPack.")
-
-set(CPACK_PACKAGE_VENDOR "Julius Herg")
+set(CPACK_PACKAGE_VENDOR "Julius Herb")
 set(CPACK_PACKAGE_CONTACT "julius@jherb.de")
 set(CPACK_PACKAGE_MAINTAINERS "Julius Herb ${CPACK_PACKAGE_CONTACT}")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/juliusgh/cpack-exercise-wt2223")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_GENERATOR "TGZ;DEB")
 
 include(CPack)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,11 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE cpack example project")
+set(CPACK_PACKAGE_DESCRIPTION "This is an example project to test CPack.")
+
+set(CPACK_PACKAGE_VENDOR "Julius Herg")
+set(CPACK_PACKAGE_CONTACT "julius@jherb.de")
+set(CPACK_PACKAGE_MAINTAINERS "Julius Herb ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/juliusgh/cpack-exercise-wt2223")
+
+include(CPack)

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -1,0 +1,5 @@
+# Debian packaging section
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+include(CPack)
+


### PR DESCRIPTION
Steps to reproduce (inside the container):
1. Switch to build folder:
`cd /mnt/cpack-exercise/ && mkdir -p build && cd build/`
2. Run cmake:
`cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..`
3. Build the package:
`make package`
4. Run the package linter:
`lintian ./cpackexample-0.1.0-Linux.deb `

![Screenshot from 2022-12-01 17-09-48](https://user-images.githubusercontent.com/43179176/206390801-90c1b772-597d-4809-95b0-dd131f6a0078.png)
