### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,19 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+# Set up library includes
+target_include_directories(cpackexamplelib
+    PRIVATE
+        # where the library itself will look for its internal headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/cpackexamplelib
+    PUBLIC
+        # where top-level project will look for the library's public headers
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cpackexamplelib>
+        # where external projects will look for the library's public headers
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
 
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
@@ -26,3 +39,17 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  )
+
+# Adding other cmake modules (standard like this)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# Include our packaging module (standard like this)
+include(CPackConfig)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,14 @@ RUN apt-get -qq update && \
         libdeal.ii-dev \
         vim \
         tree \
-        lintian
+        lintian \
+	libyaml-cpp-dev
         
 # Get, unpack, build, and install yaml-cpp        
-RUN mkdir software && cd software && \
-    git clone https://github.com/jbeder/yaml-cpp.git && \
-    cd yaml-cpp && mkdir build && cd build && \
-    cmake -DYAML_BUILD_SHARED_LIBS=ON .. && make -j4 && make install
+# RUN mkdir software && cd software && \
+#     git clone https://github.com/jbeder/yaml-cpp.git && \
+#     cd yaml-cpp && mkdir build && cd build && \
+#     cmake -DYAML_BUILD_SHARED_LIBS=ON .. && make -j4 && make install
     
 # This is some strange Docker problem. Normally, you don't need to add /usr/local to these
 ENV LIBRARY_PATH $LIBRARY_PATH:/usr/local/lib/

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,17 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "lacerdar")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE CPack example"
+	CACHE STRING "Exemplary packaging of a C++ code using CPack as part of the SSE course at the University of Stuttgart")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/iatzak/cpack-exercise-wt2223")
+set(CPACK_PACKAGE_MAINTAINER "lacerdar")
+set(CPACK_PACKAGE_CONTACT "st171197@stud.uni-stuttgart.de")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+# Debian packaging section
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+set(CPACK_STRIP_FILES TRUE)
+
+include(CPack)


### PR DESCRIPTION
In order to install the package:

1. After cloning the repository, build a docker image: `docker build -t cpack_exercise .`
2. Run a container from the built image: `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise cpack_exercise`
3. You should be inside the container, in the root folder. Create a `build` directory: `mkdir mnt/cpack-exercise/build && cd mnt/cpack-exercise/build/`
4. Create the Makefile: `cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..`
5. Create the packages: `make package`
6. Install the Debian package: `apt install ./cpackexample_0.1.0_amd64.deb`
7. You should now be able to run `cpackexample` and check that the executable is located in `/usr/bin` by running `which cpackexample`

Lintian output after striping files:
![Screenshot from 2022-12-07 19-48-48](https://user-images.githubusercontent.com/112731474/206275292-235f10ee-76f5-4cf4-92a1-161f6fe08432.png)

I did the optional task of adding `libyaml-cpp` to the list of dependencies (highlighted):
![Screenshot from 2022-12-07 19-41-48](https://user-images.githubusercontent.com/112731474/206275467-fc064a14-1a81-42ea-8699-bc9daa3b2fc6.png)
For this, the Dockerfile was modified to install `libyaml-cpp-dev` via `apt`, instead of cloning from GitHub and installing via `make install`.