### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,24 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "fem/fem.hpp;filesystem/filesystem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME} cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+  )
+
+include(cmake/CPackConfig.cmake)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,13 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE cpack exercise solution- bhawsina")
+set(CPACK_PACKAGE_VENDOR "bhawsina CPack Solution")
+set(CPACK_PACKAGE_MAINTAINERS "Nistha Bhawsinka")
+set(CPACK_PACKAGE_CONTACT "nistha.bhawsinka@gmail.com")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/CodyGirl/cpack-exercise-wt2223")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+include(CPack)


### PR DESCRIPTION
Instructions to replicate the exercise:

- Clone the repository using
``` git clone <repository_name>```
- Go inside the repository directory
```cd cpack-exercise-wt2223```
- Build Docker image: 
```docker build -t <Image_name> .```
- Run the docker container and mount the current working directory
```docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise <Image_name>```
- Create the package by using the sequence of commands given below:
```
cd /mnt/cpack-exercise
mkdir build
cd build
cmake ..
make
make package
```
- Install this newly created package
``` apt install ./cpackexample_0.1.0_amd64.deb```
- Test this package
```cpackexample```
- Check location of installed package
```which cpackexample```
- Inspect the Debian package using lintian
```lintian ./cpackexample_0.1.0_amd64.deb```
![cpack](https://user-images.githubusercontent.com/14803653/206277774-97af12bb-1f8b-42ba-8c94-3e5535d61863.jpg)

- Check the size of both deb and tar files using the below command (with CPACK_STRIP_FILES "TRUE")
```du -h <file_name>```
![size](https://user-images.githubusercontent.com/14803653/206278014-8e698161-ff25-4fab-b2b7-7f174e3fb904.jpg)
- File size after setting the flag to false (without CPACK_STRIP_FILES "TRUE")
![size2](https://user-images.githubusercontent.com/14803653/206278146-b4925a70-b676-4181-b21d-8e306514873d.jpg)
