### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,16 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+# Set up library includes
+target_include_directories(cpackexamplelib
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/filesystem
+        ${CMAKE_CURRENT_SOURCE_DIR}/fem
+        ${CMAKE_CURRENT_SOURCE_DIR}/flatset
+        ${CMAKE_CURRENT_SOURCE_DIR}/yamlParser
+)
 
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
@@ -26,3 +36,18 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+# Create install targets
+include(GNUInstallDirs)
+install(TARGETS cpackexamplelib cpackexample
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexample
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexample
+  )
+
+# Adding other cmake modules (standard like this)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# Include our packaging module (standard like this)
+include(CPackConfig)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-From ubuntu:22.04
+FROM ubuntu:22.04
 
 COPY inittimezone /usr/local/bin/inittimezone
 

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,15 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Exercise to try to package the code from the CMake exercise with CPack"
+	CACHE STRING "CPack")
+
+set(CPACK_PACKAGE_VENDOR "Anja Bergdolt")
+set(CPACK_PACKAGE_CONTACT "st185718@stud.uni-stuttgart.de")
+set(CPACK_PACKAGE_MAINTAINERS "Anja Bergdolt ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/bergdola/cpack-exercise-wt2223")
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_STRIP_FILES TRUE)
+
+include(CPack)


### PR DESCRIPTION
1. clone my fork: `git clone https://github.com/bergdola/cpack-exercise-wt2223.git`
2. change directory to `cpack-exercise-wt2223`
3. create image `docker build -t IMAGENAME .`
4. create container `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME`
5. in the container `cd mnt/cpack-exercise`
6. `mkdir build && cd build`
7. `cmake .. `
8. `make`
9. `make package`
10. `lintian ./cpackexample_0.1.0_amd64.deb`
11. done :sunflower:
![Screenshot from 2022-12-08 15-46-28](https://user-images.githubusercontent.com/116808098/206476789-f1277d94-49e9-4543-99da-f3d0fb159515.png)


