### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,33 @@ find_package(yaml-cpp
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "fem/fem.hpp;filesystem/filesystem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+target_include_directories(cpackexamplelib
+	  PRIVATE
+	    # where the library itself will look for its internal headers
+	    ${CMAKE_CURRENT_SOURCE_DIR}
+	  PUBLIC
+	    # where top-level project will look for the library's public headers
+	    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	    # where external projects will look for the library's public headers
+	    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
+
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(CPackConfig)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get -qq update && \
         libdeal.ii-dev \
         vim \
         tree \
-        lintian
+        lintian \
+        libyaml-cpp-dev
         
 # Get, unpack, build, and install yaml-cpp        
 RUN mkdir software && cd software && \
@@ -28,4 +29,7 @@ ENV LIBRARY_PATH $LIBRARY_PATH:/usr/local/lib/
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/lib/
 ENV PATH $PATH:/usr/local/bin/
 
-CMD ["/bin/bash"]
+# Initial interactive container:
+# CMD ["/bin/bash"]
+# (BONUS) Package creation automatization:
+CMD mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ../mnt/cpack-exercise && make package && mv -t ../mnt/cpack-exercise cpackexample_0.1.0_amd64.deb cpackexample-0.1.0-Linux.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ ENV PATH $PATH:/usr/local/bin/
 # Initial interactive container:
 # CMD ["/bin/bash"]
 # (BONUS) Package creation automatization:
-CMD mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ../mnt/cpack-exercise && make package && mv -t ../mnt/cpack-exercise cpackexample_0.1.0_amd64.deb cpackexample-0.1.0-Linux.tar.gz
+CMD mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ../mnt/cpack-exercise && make package && mv -t ../mnt/cpack-exercise cpackexample_0.1.0_amd64.deb cpackexample-0.1.0-Linux.tar.gz && /bin/bash

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,15 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "tuyetltg")
+set(CPACK_PACKAGE_CONTACT "Katrin Truong <st181505@stud.uni-stuttgart.de>")
+set(CPACK_PACKAGE_MAINTAINERS "tuyetltg")
+set(CPACK_PACKAGE_DESCRIPTION "This package contains a proposed solution for exersice 03 covering CPack of the lecture Simulation Software Engineering.")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE CPack exercise"
+    CACHE STRING "Extended summary.")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/PommesFrittes/cpack-exercise-wt2223")
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_GENERATOR "TGZ;DEB")
+
+include(CPack)


### PR DESCRIPTION
**How to test the code:**
1. Clone the repository and navigate to the location of the local repository. 
2. Build new docker image from Dockerfile: 
    `docker build -t IMAGENAME .`
3. Run container from the image you just built. This will open an interactive container: 
    `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME`
> **_NOTE:_**  Running the container will automatically generate `tar.gz` and `deb` packages at the current location on the host system. (Bonus task)
4. Inside the container, you will find yourself in a directory called `build`. From there, run `make package` to package the project.
5. Run the command `apt install ./cpackexample_0.1.0_amd64.deb` to install the Debian package.
6. Now, you can run the code by calling `cpackexample` from anywhere in the container.

**Additional documentation on (optional) tasks:**
- **Task 3:** Modify the Dockerfile such that `libyaml-cpp` also properly appears as dependency.
    ![Screenshot from 2022-12-07 20-55-26](https://user-images.githubusercontent.com/43793681/206304094-d04e0812-844d-420c-a7d3-a1a4aadbc087.png)
- **Task 4:** Inspect the Debian package with `lintian`.
    ![lintian](https://user-images.githubusercontent.com/43793681/206304613-5bb5f182-dd64-4808-98f4-4c2c773896e1.png)
- **Task 4:** Difference in file size of the stripped vs. unstripped files.
    Unstripped: 
    ![unstripped](https://user-images.githubusercontent.com/43793681/206305912-6ce2bf38-3a71-4960-9ba9-090fa7546e73.png)
    Stripped:
    ![stripped](https://user-images.githubusercontent.com/43793681/206305838-0e8de6c5-452b-4321-a303-372e2e482a34.png)
- **Task 4:** Fix some errors and warnings
    - Eliminate the `extended-description-is-empty` error: Add `set(CPACK_PACKAGE_DESCRIPTION "[desciption text]")` to `CPackConfig.cmake`.
    - Eliminate the `no-phrase` error: Add my name to `set(CPACK_PACKAGE_CONTACT "[contact data]")` in `CPackConfig.cmake`.
    - Eliminate the `unstripped-binary-or-object ` errors: add `set(CPACK_STRIP_FILES TRUE)` to `CPackConfig.cmake`.
    Final `lintian` output:
    ![lintian-final](https://user-images.githubusercontent.com/43793681/206307957-d6b95fd4-8f02-42d4-a46d-c40f1f322ce1.png)


