### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,34 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "fem/fem.hpp;filesystem/filesystem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+target_include_directories(cpackexamplelib
+    PRIVATE
+        # where the library itself will look for its internal headers
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+        # where top-level project will look for the library's public headers
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        # where external projects will look for the library's public headers
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 add_executable("${PROJECT_NAME}" main.cpp)
+
+include(GNUInstallDirs)
+install(TARGETS cpackexamplelib ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+  )
+
+
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(cmake/CPackConfig.cmake)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,15 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "SSE course")
+set(CPACK_PACKAGE_DESCRIPTION "Learning example of packaging C++ code.")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/chrispfae/cpack-exercise-wt2223")
+set(CPACK_PACKAGE_CONTACT "christian.someemail.de")
+
+# Generate .tar.gz and .deb file
+set(CPACK_GENERATOR "TGZ;DEB")
+# Strip the .deb file
+set(CPACK_STRIP_FILES TRUE)
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+include(CPack)


### PR DESCRIPTION
## How to guide:
1. Fetch branch of PR
2. Build docker container: `docker build -t cpackexercise .`
3. Run docker container: `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise cpackexercise`
4. Build the package 
```
mkdir /mnt/cpack-exercise/build
cd /mnt/cpack-exercise/build
cmake ..
make package
```
5. Test .deb package with `apt install ./cpackexample_0.1.0_amd64.deb` and run with `cpackexample`
6. Test .tar.gz file with `tar -xzf cpackexample-0.1.0-Linux.tar.gz` and run with `./cpackexample-0.1.0-Linux/bin/./cpackexample`
7. .deb package can be checked with `lintian *deb`. The output should be similar to the following:
![cpack](https://user-images.githubusercontent.com/116820495/206324563-e663a196-fa7d-4fc4-a16e-ef745f61766f.png)
