### PR TITLE
Adding cpack packaging to the current project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,31 @@ find_package(yaml-cpp
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp;")
+
+ # Set up library includes
+ target_include_directories( cpackexamplelib
+     PRIVATE
+         ${CMAKE_CURRENT_SOURCE_DIR}
+     PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+ )
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+ install(TARGETS cpackexample cpackexamplelib
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/includedir
+   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+   )
+
+include(cmake/CPackConfig.cmake)
+

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,17 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "CPack exercise"
+   CACHE STRING "Extended summary.")
+
+set(CPACK_PACKAGE_VENDOR "Simulation Engineering")
+set(CPACK_PACKAGE_CONTACT "mark.ashraf.fcis@hotmail.com")
+set(CPACK_PACKAGE_MAINTAINERS "Mark Youssef")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/MarkAshraf96/cpack-exercise-wt2223.git")
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+include(CPack)
+
+


### PR DESCRIPTION
Installation Steps:

- Clone the repository:
  `git clone    https://github.com/MarkAshraf96/cpack-exercise-wt2223.git`

-  Build the  docker image:
`docker build -t IMAGENAME`

- Run the docker container 
`docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME`

- Create new directory build and run cmake from inside of it
`mkdir build
cd build
cmake ..
`

- Install the package 
`apt install ./<DEBFILENAME>`

- now you can run `cpackexample` from any path.

Notes:

- Lintian Output without stripping
<img width="802" alt="debian screenshot unstripped" src="https://user-images.githubusercontent.com/40201647/206388267-9ee103ed-98bb-4568-81fc-de4e0684deb3.png">

- Lintian Output with Stripping
<img width="829" alt="debian stripped" src="https://user-images.githubusercontent.com/40201647/206388340-ee4587b3-0567-4339-8a3f-a3f261256e8f.png">




