### PR TITLE
added installation and package targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,34 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
 
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
+
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+)
+
+# Adding other cmake modules (standard like this)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# Include our packaging module (standard like this)
+include(CPackConfig)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,18 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "CPack example project"
+  CACHE STRING "Extended summary.")
+
+set(CPACK_PACKAGE_VENDOR "Johannes Erwerle")
+set(CPACK_PACKAGE_CONTACT "johannes.erwerle@example.com")
+set(CPACK_PACKAGE_MAINTAINERS "Johannes Erwerle ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/991jo/cpack-exercise-wt2223")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_STRIP_FILES YES)
+
+
+include(CPack)


### PR DESCRIPTION
```
E: cpackexample: extended-description-is-empty
E: cpackexample: lacks-ldconfig-trigger usr/lib/libcpackexamplelib.so
E: cpackexample: no-changelog usr/share/doc/cpackexample/changelog.gz (native package)
E: cpackexample: no-copyright-file
E: cpackexample: no-phrase Maintainer johannes.erwerle@example.com
W: cpackexample: maintscript-calls-ldconfig [postinst]
W: cpackexample: maintscript-calls-ldconfig [postrm]
W: cpackexample: no-manual-page usr/bin/cpackexample
W: cpackexample: package-name-doesnt-match-sonames libcpackexamplelib
W: cpackexample: shared-library-lacks-version usr/lib/libcpackexamplelib.so libcpackexamplelib.so
```